### PR TITLE
Remove UTM Type Column

### DIFF
--- a/models/base/segment_web_page_views.sql
+++ b/models/base/segment_web_page_views.sql
@@ -52,7 +52,6 @@ renamed as (
         context_campaign_name as utm_campaign,
         context_campaign_term as utm_term,
         context_campaign_content as utm_content,
-        context_campaign_type as utm_type,
         {{ dbt_utils.get_url_parameter('url', 'gclid') }} as gclid,
         context_ip as ip,
         context_user_agent as user_agent,

--- a/models/sessionization/segment_web_sessions__initial.sql
+++ b/models/sessionization/segment_web_sessions__initial.sql
@@ -21,7 +21,6 @@
     'utm_medium' : 'utm_medium',
     'utm_campaign' : 'utm_campaign',
     'utm_term' : 'utm_term',
-    'utm_type' : 'utm_type',
     'gclid' : 'gclid',
     'page_url' : 'first_page_url',
     'page_url_host' : 'first_page_url_host',


### PR DESCRIPTION
## Description & motivation

UTM Type is a non-standard UTM column.Removing the static references. 

Additional columns can be passed through using the project variable `segment_pass_through_columns`. 

Fixes #5

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
