### PR TITLE
Fix Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This [dbt package](https://docs.getdbt.com/docs/package-management):
 
 ## Installation instructions
 New to dbt packages? Read more about them [here](https://docs.getdbt.com/docs/building-a-dbt-project/package-management/).
-1. Include this package in your `packages.yml` — check [here](https://hub.getdbt.com/dbt-labs/segment/latest/) for the latest version number.
+1. Include this package in your `packages.yml` — check [here](https://hub.getdbt.com/Fleetio/dbt_segment/latest/) for the latest version number.
 2. Run `dbt deps`
 3. Include the following in your `dbt_project.yml` directly within your `vars:` block (making sure to handle indenting appropriately). **Update the value to point to your segment page views table**.
 


### PR DESCRIPTION
## Description & motivation
Switch link to point at the Fleetio forked version in the README.

## Checklist
- [ ] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
