### PR TITLE
BigQuery fix cast issue in segment_web_page_views

### DIFF
--- a/models/base/segment_web_page_views.sql
+++ b/models/base/segment_web_page_views.sql
@@ -7,7 +7,7 @@ The if statement below checks to see if segment_page_views_table is a string or 
 {% if var('segment_page_views_table') is string %}
     
     unioned_sources AS (
-        select cast('segment_page_views_table' as text) as source_name, * from {{var('segment_page_views_table')}}
+        select {{ dbt.safe_cast("'segment_page_views_table'", api.Column.translate_type("string")) }} as source_name, * from {{var('segment_page_views_table')}}
     ),
 
 


### PR DESCRIPTION
## Description & motivation
This solves the issue #18 (compatibility with BigQuery).
I replaced `cast` with `dbt.safe_cast` macro for cross-database support.

Environment where it's been tested:
- Python==3.12.3
- dbt==1.7.14
- dbt-snowflake==1.7.3
- dbt-bigquery==1.7.8
- dbt-labs/dbt_utils==1.1.1

I tested it against Snowflake and BigQuery.
I don't currently have access to Segment data, so I tested this specific line on non-segment data. The result is as expected, though — it generates a string column with 'segment_page_views_table' value.

## Checklist
- [x] I have verified that these changes work locally
- [] I have updated the README.md (if applicable)
- [] I have added tests & descriptions to my models (and macros if applicable)
